### PR TITLE
remove unnecessary variables in line chart code examples

### DIFF
--- a/pattern-library/data-visualization/line-chart/index.html
+++ b/pattern-library/data-visualization/line-chart/index.html
@@ -643,9 +643,6 @@
     ['data4', 10, 340, 30, 290, 35, 20],
     ['data5', 90, 150, 160, 165, 180, 5]
   ];
-  var singleLineChartDataColumns = [
-    ['data1', 30, 200, 100, 400, 150, 250]
-  ];
 
   var c3ChartDefaults = $().c3ChartDefaults();
   var lineChartConfig = c3ChartDefaults.getDefaultLineConfig();
@@ -666,13 +663,6 @@
       <div class="example-pf">
         <div id="line-chart-4" class="line-chart-pf"></div>
 <script>
-  var lineChartDataColumns = [
-    ['data1', 30, 200, 100, 400, 150, 250],
-    ['data2', 50, 220, 310, 240, 115, 25],
-    ['data3', 70, 100, 390, 295, 170, 220],
-    ['data4', 10, 340, 30, 290, 35, 20],
-    ['data5', 90, 150, 160, 165, 180, 5]
-  ];
   var singleLineChartDataColumns = [
     ['data1', 30, 200, 100, 400, 150, 250]
   ];


### PR DESCRIPTION
The multi-series line chart example included example data for the
single-series example.  Similarly, the single-series line chart
example included example data for the multi-series example.  This
commit removes the unnecessary variables from each example.