### PR TITLE
update bootstrap-switch.org to bootstrapswitch.com docs

### DIFF
--- a/pattern-library/widgets/index.html
+++ b/pattern-library/widgets/index.html
@@ -1022,7 +1022,7 @@ Bootstrap JavaScript modular. PatternFly also uses <a href="http://c3js.org/" ta
   </div>
 <div class="section" id="bootstrap-switch">
     <h3>Bootstrap Switch</h3>
-    <p>See <a href="http://www.bootstrap-switch.org/">http://www.bootstrap-switch.org/</a> for complete Bootstrap Switch documentation.</p>
+    <p>See <a href="http://bootstrapswitch.com/">http://bootstrapswitch.com/</a> for complete Bootstrap Switch documentation.</p>
     <div class="pf-example">
       <input class="bootstrap-switch" id="bootstrap-switch-state" type="checkbox" checked="" />
       <script>


### PR DESCRIPTION
not 100% percent that this is the corrected host, but regardless there's a 404 in the switches current docs.